### PR TITLE
fix call to super; fix call to delete_password; bring out more options to __init__

### DIFF
--- a/keyringcookiejar/__init__.py
+++ b/keyringcookiejar/__init__.py
@@ -6,24 +6,29 @@ class KeyringCookieJar(CookieJar):
   DEFAULT_SERVICE = "Python Keyring Cookie Jar"
 
   def __init__(self, svc=DEFAULT_SERVICE, acct=None,
-      delayload=False, policy=None):
+      delayload=False, policy=None,
+      ignore_discard=False, ignore_expires=False):
 
     CookieJar.__init__(self, policy)
     self.svc = "Cookies for " + svc
     self.acct = getpass.getuser() if acct is None else acct
     self.delayload = bool(delayload)
 
-    if not self.delayload: self.load()
+    if not self.delayload: self.load(ignore_discard, ignore_expires)
 
 
   def clear(self, domain=None, path=None, name=None):
-    super(KeyringCookieJar, self).clear(domain, path, name)
+    if issubclass(CookieJar, object):
+      super(KeyringCookieJar, self).clear(domain, path, name)
+    else:
+      # old-style class in Python 2
+      CookieJar.clear(self, domain, path, name)
     self.nuke()
     self.save()
 
 
   def nuke(self):
-    self.delete_password(self.svc, self.acct)
+    keyring.delete_password(self.svc, self.acct)
 
 
   def save(self, ignore_discard=False, ignore_expires=False):

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,6 @@ setup(
   description = 'Store cookies using the keyring package',
   author = 'Tom Maher',
   author_email = 'tmaher@pw0n.me',
-  url = 'https://github.com/tmaher/keyringcookiejar',
-  download_url = 'https://github.com/tmaher/keyringcookiejar/tarball/0.1', # I'll explain this in a second
-  install_requires =[
-    'keyring',
-  ],
-  classifiers = [],
+  url = 'https://github.com/PARC/keyringcookiejar',
+  install_requires =['keyring']
 )


### PR DESCRIPTION
Fix call to super() for Python 2.
Fix call to delete_password().
Bring ignore_discard and ignore_expires out to **init** so that you can load a keyring cookiejar with discarded and/or expired cookies in it.
